### PR TITLE
grammar and content updates

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -342,7 +342,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td><code class="prettyprint">roomid</code></td>
 <td><code class="prettyprint">433</code></td>
 <td>Optional</td>
-<td>The room id (not to be confused, with the room name).</td>
+<td>The room ID (not to be confused, with the <code class="prettyprint">roomname</code>).</td>
 </tr>
 <tr>
 <td><code class="prettyprint">roomname</code></td>
@@ -354,13 +354,13 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td><code class="prettyprint">siteid</code></td>
 <td><code class="prettyprint">086</code></td>
 <td>Optional</td>
-<td>Every room is inside a site (building). All sites have ids.</td>
+<td>Every room is inside a site (building). All sites have IDs.</td>
 </tr>
 <tr>
 <td><code class="prettyprint">sitename</code></td>
 <td><code class="prettyprint">Torrington Place, 1-19</code></td>
 <td>Optional</td>
-<td>Every site (building) has a name. In some cases this is contained in the room name as well.</td>
+<td>Every site (building) has a name. In some cases this is contained in the <code class="prettyprint">roomname</code> as well.</td>
 </tr>
 <tr>
 <td><code class="prettyprint">classification</code></td>
@@ -418,12 +418,12 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td><code class="prettyprint">roomid</code></td>
 <td><code class="prettyprint">Z4</code></td>
-<td>The room id (not to be confused with the room name)</td>
+<td>The room ID (not to be confused with the <code class="prettyprint">roomname</code>)</td>
 </tr>
 <tr>
 <td><code class="prettyprint">siteid</code></td>
 <td><code class="prettyprint">005</code></td>
-<td>Every room is inside a site (building). All sites have ids.</td>
+<td>Every room is inside a site (building). All sites have IDs.</td>
 </tr>
 <tr>
 <td><code class="prettyprint">sitename</code></td>
@@ -517,7 +517,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td>roomid</td>
 <td><code class="prettyprint">433</code></td>
 <td>Optional</td>
-<td>The room id (not to be confused with the room name)</td>
+<td>The room ID (not to be confused with the <code class="prettyprint">roomname</code>)</td>
 </tr>
 <tr>
 <td>start_datetime</td>
@@ -535,13 +535,13 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td>date</td>
 <td><code class="prettyprint">20160202</code></td>
 <td>Optional</td>
-<td>Date of the bookings you need. Returns bookings occuring on this day. <strong>This query parameter is only considered when <code class="prettyprint">end_datetime</code> and <code class="prettyprint">start_datetime</code> are not supplied.</strong></td>
+<td>Date of the bookings you need, in the format <em>YYYYMMDD</em>. Returns bookings occurring on this day. <strong>This query parameter is only considered when <code class="prettyprint">end_datetime</code> and <code class="prettyprint">start_datetime</code> are not supplied.</strong></td>
 </tr>
 <tr>
 <td>siteid</td>
 <td><code class="prettyprint">086</code></td>
 <td>Optional</td>
-<td>Every room is inside a site (building). All sites have ids.</td>
+<td>Every room is inside a site (building). All sites have IDs.</td>
 </tr>
 <tr>
 <td>description</td>
@@ -553,7 +553,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td>contact</td>
 <td><code class="prettyprint">Mark Herbster</code></td>
 <td>Optional</td>
-<td>The name of the person who made the booking. Can substrings of the contact name: Queries for <code class="prettyprint">Mark</code> will include <code class="prettyprint">Mark Herbster</code>.</td>
+<td>The name of the person who made the booking. Substrings of the contact name can be used: Queries for <code class="prettyprint">Mark</code> will include <code class="prettyprint">Mark Herbster</code>. Sometimes, a society or student group may be the contact for a booking.</td>
 </tr>
 <tr>
 <td>results_per_page</td>
@@ -561,10 +561,17 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td>Optional</td>
 <td>Number of bookings returned per page. Maximum allowed value is <code class="prettyprint">100</code>. Defaults to <code class="prettyprint">20</code>.</td>
 </tr>
+<tr>
+<td>roomname</td>
+<td><code class="prettyprint">Cruciform Building B.3.05</code></td>
+<td>Optional</td>
+<td>The name of the room. It often includes the name of the site (building) as well.</td>
+</tr>
 </tbody></table>
 
 <h4 id="response">Response</h4>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+   </span><span class="s2">"ok"</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">,</span><span class="w">
    </span><span class="s2">"bookings"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
       </span><span class="p">{</span><span class="w">  
           </span><span class="s2">"slotid"</span><span class="p">:</span><span class="w"> </span><span class="mi">998503</span><span class="p">,</span><span class="w">
@@ -580,9 +587,8 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
        </span><span class="p">},</span><span class="w">
        </span><span class="err">...</span><span class="w">
     </span><span class="p">],</span><span class="w">
-    </span><span class="s2">"page_token"</span><span class="p">:</span><span class="w"> </span><span class="s2">"6hb14hXjRV"</span><span class="p">,</span><span class="w">
-    </span><span class="s2">"ok"</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">,</span><span class="w">
     </span><span class="s2">"next_page_exists"</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">,</span><span class="w">
+    </span><span class="s2">"page_token"</span><span class="p">:</span><span class="w"> </span><span class="s2">"6hb14hXjRV"</span><span class="p">,</span><span class="w">
     </span><span class="s2">"count"</span><span class="p">:</span><span class="w"> </span><span class="mi">1197</span><span class="w">
 </span><span class="p">}</span><span class="w">
 
@@ -597,7 +603,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td>ok</td>
 <td><code class="prettyprint">true</code></td>
-<td>Whether the request was successful</td>
+<td>Boolean indicating whether the request was successful.</td>
 </tr>
 <tr>
 <td>bookings</td>
@@ -607,7 +613,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td>next_page_exists</td>
 <td><code class="prettyprint">true</code></td>
-<td>True if there is another page with more bookings.</td>
+<td>True if there is another page containing more bookings.</td>
 </tr>
 <tr>
 <td>page_token</td>
@@ -628,12 +634,12 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td>slotid</td>
 <td><code class="prettyprint">1024991</code></td>
-<td>An id for the booking. Combined with <code class="prettyprint">weeknumber</code> they can be assumed to be almost unique.</td>
+<td>An ID for the booking. Combined with <code class="prettyprint">weeknumber</code> they can be assumed to be almost unique.</td>
 </tr>
 <tr>
 <td>contact</td>
 <td><code class="prettyprint">Wilhelm Klopp - UCLU Tech Society</code></td>
-<td>Name of the person who made the booking</td>
+<td>Name of the person (and society/student group, if applicable) who made the booking.</td>
 </tr>
 <tr>
 <td>start_time</td>
@@ -648,7 +654,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td>roomid</td>
 <td><code class="prettyprint">B305</code></td>
-<td>The room ID (not to be confused with the room name)</td>
+<td>The room ID (not to be confused with the <code class="prettyprint">roomname</code>).</td>
 </tr>
 <tr>
 <td>roomname</td>
@@ -658,7 +664,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td>siteid</td>
 <td><code class="prettyprint">044</code></td>
-<td>Every room is inside a site (building). All sites have ids.</td>
+<td>Every room is inside a site (building). All sites have IDs.</td>
 </tr>
 <tr>
 <td>weeknumber</td>
@@ -668,7 +674,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td>phone</td>
 <td><code class="prettyprint">45699</code></td>
-<td>Phone number (UCL extension)</td>
+<td>Phone number of the room (UCL extension).</td>
 </tr>
 <tr>
 <td>count</td>
@@ -681,9 +687,9 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 
 <p><strong>Endpoint:</strong> <code class="prettyprint">https://uclapi.com/roombookings/bookings</code></p>
 
-<p>Paginated requests also go to the <code class="prettyprint">/bookings</code> endpoint, but other than the regular requests only the <code class="prettyprint">token</code> and <code class="prettyprint">page_token</code> should be supplied. All other filters are &ldquo;remembered&rdquo; from the initiating regular request.</p>
+<p>Paginated requests also go to the <code class="prettyprint">/bookings</code> endpoint but, unlike the regular requests, only the <code class="prettyprint">token</code> and <code class="prettyprint">page_token</code> should be supplied. All other filters are &ldquo;remembered&rdquo; from the initiating regular request.</p>
 
-<p>The API remembers how many requests you&rsquo;ve made, so to move through the pages you can keep making the same request (with the same <code class="prettyprint">token</code> and <code class="prettyprint">page_token</code>) until the response contains <code class="prettyprint">false</code> in the <code class="prettyprint">next_page_exists</code> field.</p>
+<p>The API &ldquo;remembers&rdquo; how many requests you&rsquo;ve made, so to move through the pages you can keep making the same request (with the same <code class="prettyprint">token</code> and <code class="prettyprint">page_token</code>) until the response&rsquo;s <code class="prettyprint">next_page_exists</code> field is <code class="prettyprint">false</code>.</p>
 
 <p><strong>Allowed request type:</strong> <code class="prettyprint">GET</code></p>
 
@@ -724,7 +730,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td><code class="prettyprint">page_token</code></td>
 <td><code class="prettyprint">6hb14hXjRV</code></td>
 <td>Required</td>
-<td>Page token received in regular <code class="prettyprint">/bookings</code> request. The page token does not change as you paginate through the results.</td>
+<td>Page token received in initial <code class="prettyprint">/bookings</code> request. The page token does not change as you paginate through the results.</td>
 </tr>
 </tbody></table>
 
@@ -786,7 +792,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 
 <p><strong>Endpoint:</strong> <code class="prettyprint">https://uclapi.com/roombookings/equipment</code></p>
 
-<p>This endpoint returns equipment/feature information about a specific room. So, for example whether there is a <code class="prettyprint">Whiteboard</code> or a <code class="prettyprint">DVD Player</code> in the room. A full example can be seen <a href="https://roombooking.ucl.ac.uk/rb/bookableSpace/roomInfo.html?room=B15B&amp;building=016&amp;invoker=EFD">here.</a></p>
+<p>This endpoint returns any equipment/feature information about a specific room. So, for example whether there is a <code class="prettyprint">Whiteboard</code> or a <code class="prettyprint">DVD Player</code> in the room. A full example can be seen <a href="https://roombooking.ucl.ac.uk/rb/bookableSpace/roomInfo.html?room=B15B&amp;building=016&amp;invoker=EFD">here.</a></p>
 
 <p>You <em>need</em> to supply a <code class="prettyprint">token</code>, <code class="prettyprint">roomid</code>, and <code class="prettyprint">siteid</code> to get a response.</p>
 
@@ -824,13 +830,13 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td><code class="prettyprint">roomid</code></td>
 <td><code class="prettyprint">433</code></td>
 <td>Required</td>
-<td>The room id (not to be confused with the room name)</td>
+<td>The room ID (not to be confused with the <code class="prettyprint">roomname</code>)</td>
 </tr>
 <tr>
 <td><code class="prettyprint">siteid</code></td>
 <td><code class="prettyprint">086</code></td>
 <td>Required</td>
-<td>Every room is inside a site (building). All sites have ids.</td>
+<td>Every room is inside a site (building). All sites have IDs.</td>
 </tr>
 </tbody></table>
 

--- a/build/index.html
+++ b/build/index.html
@@ -336,7 +336,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td><code class="prettyprint">token</code></td>
 <td><code class="prettyprint">uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb</code></td>
 <td>Required</td>
-<td>Authentication token</td>
+<td>Authentication token.</td>
 </tr>
 <tr>
 <td><code class="prettyprint">roomid</code></td>
@@ -366,7 +366,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td><code class="prettyprint">classification</code></td>
 <td><code class="prettyprint">CR</code></td>
 <td>Optional</td>
-<td>The type of room. <code class="prettyprint">LT</code> = Lecture Theatre, <code class="prettyprint">CR</code> = Classroom, <code class="prettyprint">SS</code> = Social Space, <code class="prettyprint">PC1</code> = Public Cluster</td>
+<td>The type of room. <code class="prettyprint">LT</code> = Lecture Theatre, <code class="prettyprint">CR</code> = Classroom, <code class="prettyprint">SS</code> = Social Space, <code class="prettyprint">PC1</code> = Public Cluster.</td>
 </tr>
 <tr>
 <td><code class="prettyprint">capacity</code></td>
@@ -418,7 +418,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td><code class="prettyprint">roomid</code></td>
 <td><code class="prettyprint">Z4</code></td>
-<td>The room ID (not to be confused with the <code class="prettyprint">roomname</code>)</td>
+<td>The room ID (not to be confused with the <code class="prettyprint">roomname</code>).</td>
 </tr>
 <tr>
 <td><code class="prettyprint">siteid</code></td>
@@ -438,7 +438,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <tr>
 <td><code class="prettyprint">classification</code></td>
 <td><code class="prettyprint">SS</code></td>
-<td>The type of room. <code class="prettyprint">LT</code> = Lecture Theatre, <code class="prettyprint">CR</code> = Classroom, <code class="prettyprint">SS</code> = Social Space, <code class="prettyprint">PC1</code> = Public Cluster</td>
+<td>The type of room. <code class="prettyprint">LT</code> = Lecture Theatre, <code class="prettyprint">CR</code> = Classroom, <code class="prettyprint">SS</code> = Social Space, <code class="prettyprint">PC1</code> = Public Cluster.</td>
 </tr>
 <tr>
 <td><code class="prettyprint">automated</code></td>
@@ -511,13 +511,13 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 <td>token</td>
 <td><code class="prettyprint">uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb</code></td>
 <td>Required</td>
-<td>Authentication token</td>
+<td>Authentication token.</td>
 </tr>
 <tr>
 <td>roomid</td>
 <td><code class="prettyprint">433</code></td>
 <td>Optional</td>
-<td>The room ID (not to be confused with the <code class="prettyprint">roomname</code>)</td>
+<td>The room ID (not to be confused with the <code class="prettyprint">roomname</code>).</td>
 </tr>
 <tr>
 <td>start_datetime</td>
@@ -776,7 +776,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 </tr>
 <tr>
 <td><code class="prettyprint">date/time isn&#39;t formatted as suggested in the docs</code></td>
-<td>Passed datetime parameter do not conform to the ISO8601 format</td>
+<td>Passed datetime parameter does not conform to the ISO8601 format</td>
 </tr>
 <tr>
 <td><code class="prettyprint">results_per_page should be an integer</code></td>
@@ -784,7 +784,7 @@ If you don&rsquo;t specify any query parameters besides the <code class="prettyp
 </tr>
 <tr>
 <td><code class="prettyprint">Page token does not exist</code></td>
-<td>passed <code class="prettyprint">page_token</code> parameter isn&rsquo;t a valid one.</td>
+<td>The passed <code class="prettyprint">page_token</code> parameter isn&rsquo;t a valid one.</td>
 </tr>
 </tbody></table>
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -223,7 +223,7 @@ siteid | `086` | Optional | Every room is inside a site (building). All sites ha
 description | `Lecture` | Optional | Describes what the booking is. Could contain a module code (for example `WIBRG005`) or just the type of activity (for example `Lecture`).
 contact | `Mark Herbster` | Optional | The name of the person who made the booking. Substrings of the contact name can be used: Queries for `Mark` will include `Mark Herbster`. Sometimes, a society or student group may be the contact for a booking.
 results_per_page | `50` | Optional | Number of bookings returned per page. Maximum allowed value is `100`. Defaults to `20`.
-roomname | `Cruciform Building B.3.05` | The name of the room. It often includes the name of the site (building) as well.
+roomname | `Cruciform Building B.3.05` | Optional | The name of the room. It often includes the name of the site (building) as well.
 
 
 #### Response

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -77,7 +77,7 @@ On the right hand side you'll see a code sample with the version data added. We 
 The base url is `https://uclapi.com/roombookings/`
 
 Version Header | Latest Version
----------- | -----------
+-------------- | --------------
 `uclapi-roombookings-version` | `1`
 
 ## Get Rooms
@@ -116,12 +116,12 @@ fetch("https://uclapi.com/roombookings/rooms?token=uclapi-5d58c3c4e6bf9c-c2910ad
 ```
 
 Parameter | Example | Required | Description
---------- | ---------- | ----------- | -----------
-`token` | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token
-`roomid` | `433` | Optional | The room id (not to be confused, with the room name).
+--------- | ------- | -------- | -----------
+`token`   | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token
+`roomid` | `433` | Optional | The room ID (not to be confused, with the `roomname`).
 `roomname` | `Torrington (1-19) 433`| Optional | The name of the room. It often includes the name of the site (building) as well.
-`siteid` | `086`| Optional | Every room is inside a site (building). All sites have ids.
-`sitename` | `Torrington Place, 1-19`| Optional | Every site (building) has a name. In some cases this is contained in the room name as well.
+`siteid` | `086`| Optional | Every room is inside a site (building). All sites have IDs.
+`sitename` | `Torrington Place, 1-19`| Optional | Every site (building) has a name. In some cases this is contained in the `roomname` as well.
 `classification` | `CR`| Optional | The type of room. `LT` = Lecture Theatre, `CR` = Classroom, `SS` = Social Space, `PC1` = Public Cluster
 `capacity` | `55`| Optional | Every room has a set capacity of how many people can fit inside it. When supplied, all rooms with the given capacity or greater will be returned.
 
@@ -158,8 +158,8 @@ The room field contains a list of rooms that match your query. If no filters are
 Room Property | Example |  Description
 --------- | ---------- |  -----------
 `roomname` | `Wilkins Building (Main Building) Portico` | The name of the room. It often includes the name of the site (building) as well.
-`roomid` | `Z4` | The room id (not to be confused with the room name)
-`siteid` | `005`| Every room is inside a site (building). All sites have ids.
+`roomid` | `Z4` | The room ID (not to be confused with the `roomname`)
+`siteid` | `005`| Every room is inside a site (building). All sites have IDs.
 `sitename` | `Main Building` | The name of the site (building).
 `capacity` | `50` | The number of people that can fit in the room.
 `classification` | `SS`| The type of room. `LT` = Lecture Theatre, `CR` = Classroom, `SS` = Social Space, `PC1` = Public Cluster
@@ -215,14 +215,15 @@ fetch("https://uclapi.com/roombookings/bookings?token=uclapi-5d58c3c4e6bf9c-c291
 Parameter | Example | Required | Description
 ---|---|---|---
 token | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token
-roomid |  `433`  |  Optional  | The room id (not to be confused with the room name)
+roomid |  `433`  |  Optional  | The room ID (not to be confused with the `roomname`)
 start_datetime | `2011-03-06T03:36:45+00:00` | Optional | Start datetime of the booking. Returns bookings with a `start_datetime` after the one supplied. Follows the [ISO 8601 formatting standard](https://en.wikipedia.org/wiki/ISO_8601).
 end_datetime | `2011-03-06T03:36:45+00:00` | Optional | End datetime of the booking. Returns bookings with an `end_datetime` before the one supplied. Follows the [ISO 8601 formatting standard](https://en.wikipedia.org/wiki/ISO_8601).
-date | `20160202` | Optional | Date of the bookings you need. Returns bookings occuring on this day. **This query parameter is only considered when `end_datetime` and `start_datetime` are not supplied.**
-siteid | `086` | Optional | Every room is inside a site (building). All sites have ids.
+date | `20160202` | Optional | Date of the bookings you need, in the format *YYYYMMDD*. Returns bookings occurring on this day. **This query parameter is only considered when `end_datetime` and `start_datetime` are not supplied.**
+siteid | `086` | Optional | Every room is inside a site (building). All sites have IDs.
 description | `Lecture` | Optional | Describes what the booking is. Could contain a module code (for example `WIBRG005`) or just the type of activity (for example `Lecture`).
-contact | `Mark Herbster` | Optional | The name of the person who made the booking. Can substrings of the contact name: Queries for `Mark` will include `Mark Herbster`.
+contact | `Mark Herbster` | Optional | The name of the person who made the booking. Substrings of the contact name can be used: Queries for `Mark` will include `Mark Herbster`. Sometimes, a society or student group may be the contact for a booking.
 results_per_page | `50` | Optional | Number of bookings returned per page. Maximum allowed value is `100`. Defaults to `20`.
+roomname | `Cruciform Building B.3.05` | The name of the room. It often includes the name of the site (building) as well.
 
 
 #### Response
@@ -230,6 +231,7 @@ results_per_page | `50` | Optional | Number of bookings returned per page. Maxim
 
 ```json
 {
+   "ok": true,
    "bookings": [
       {  
           "slotid": 998503,
@@ -245,9 +247,8 @@ results_per_page | `50` | Optional | Number of bookings returned per page. Maxim
        },
        ...
     ],
-    "page_token": "6hb14hXjRV",
-    "ok": true,
     "next_page_exists": true,
+    "page_token": "6hb14hXjRV",
     "count": 1197
 }
 
@@ -256,32 +257,32 @@ results_per_page | `50` | Optional | Number of bookings returned per page. Maxim
 
 Field | Example | Description
 --------- | ---------- | -----------
-ok | `true` | Whether the request was successful
+ok | `true` | Boolean indicating whether the request was successful.
 bookings | - | An array of booking objects.
-next_page_exists | `true` | True if there is another page with more bookings.
+next_page_exists | `true` | True if there is another page containing more bookings.
 page_token | `6hb14hXjRV` | Page token parameter that needs to be supplied to view subsequent pages. Only included when the next page exists.
 
 The bookings array contains booking objects, which each have the following properties.
 
 Booking Property | Example | Description
 --------- | ---------- | -----------
-slotid | `1024991` | An id for the booking. Combined with `weeknumber` they can be assumed to be almost unique.
-contact | `Wilhelm Klopp - UCLU Tech Society` | Name of the person who made the booking
+slotid | `1024991` | An ID for the booking. Combined with `weeknumber` they can be assumed to be almost unique.
+contact | `Wilhelm Klopp - UCLU Tech Society` | Name of the person (and society/student group, if applicable) who made the booking.
 start_time | `2016-10-20T18:00:00+00:00` | Start datetime of the booking. Returns bookings with a `start_datetime` after the one supplied. Follows the [ISO 8601 formatting standard](https://en.wikipedia.org/wiki/ISO_8601).
 end_time | `2016-10-20T19:00:00+00:00` | End datetime of the booking. Returns bookings with an `end_datetime` before the one supplied. Follows the [ISO 8601 formatting standard](https://en.wikipedia.org/wiki/ISO_8601).
-roomid | `B305` | The room ID (not to be confused with the room name)
+roomid | `B305` | The room ID (not to be confused with the `roomname`).
 roomname | `Cruciform Building B.3.05` | The name of the room. It often includes the name of the site (building) as well.
-siteid | `044` | Every room is inside a site (building). All sites have ids.
+siteid | `044` | Every room is inside a site (building). All sites have IDs.
 weeknumber | `8` | The week the booking is in.
-phone | `45699` | Phone number (UCL extension)
+phone | `45699` | Phone number of the room (UCL extension).
 count | `1197` | Total number of bookings matching the query. The `count` field will only be in the first response to a query
 
 ### Paginated Request
 **Endpoint:** `https://uclapi.com/roombookings/bookings`
 
-Paginated requests also go to the `/bookings` endpoint, but other than the regular requests only the `token` and `page_token` should be supplied. All other filters are "remembered" from the initiating regular request.
+Paginated requests also go to the `/bookings` endpoint but, unlike the regular requests, only the `token` and `page_token` should be supplied. All other filters are "remembered" from the initiating regular request.
 
-The API remembers how many requests you've made, so to move through the pages you can keep making the same request (with the same `token` and `page_token`) until the response contains `false` in the `next_page_exists` field.
+The API "remembers" how many requests you've made, so to move through the pages you can keep making the same request (with the same `token` and `page_token`) until the response's `next_page_exists` field is `false`.
 
 **Allowed request type:** `GET`
 
@@ -316,7 +317,7 @@ fetch("https://uclapi.com/roombookings/bookings?token=uclapi-5d58c3c4e6bf9c-c291
 Parameter | Example | Required | Description
 --------- | ---------- | ----------- | -----------
 `token` | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token
-`page_token` | `6hb14hXjRV` | Required | Page token received in regular `/bookings` request. The page token does not change as you paginate through the results.
+`page_token` | `6hb14hXjRV` | Required | Page token received in initial `/bookings` request. The page token does not change as you paginate through the results.
 
 #### Response
 
@@ -358,7 +359,7 @@ Error                 | Description
 ## Get Equipment
 **Endpoint:** `https://uclapi.com/roombookings/equipment`
 
-This endpoint returns equipment/feature information about a specific room. So, for example whether there is a `Whiteboard` or a `DVD Player` in the room. A full example can be seen [here.](https://roombooking.ucl.ac.uk/rb/bookableSpace/roomInfo.html?room=B15B&building=016&invoker=EFD)
+This endpoint returns any equipment/feature information about a specific room. So, for example whether there is a `Whiteboard` or a `DVD Player` in the room. A full example can be seen [here.](https://roombooking.ucl.ac.uk/rb/bookableSpace/roomInfo.html?room=B15B&building=016&invoker=EFD)
 
 You _need_ to supply a `token`, `roomid`, and `siteid` to get a response.
 
@@ -390,8 +391,8 @@ fetch("https://uclapi.com/roombookings/equipment?token=uclapi-5d58c3c4e6bf9c-c29
 Parameter | Example | Required | Description
 --------- | ------- | -------- | -----------
 `token` | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token
-`roomid` | `433` | Required | The room id (not to be confused with the room name)
-`siteid` | `086`| Required | Every room is inside a site (building). All sites have ids.
+`roomid` | `433` | Required | The room ID (not to be confused with the `roomname`)
+`siteid` | `086`| Required | Every room is inside a site (building). All sites have IDs.
 
 ### Response
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -117,12 +117,12 @@ fetch("https://uclapi.com/roombookings/rooms?token=uclapi-5d58c3c4e6bf9c-c2910ad
 
 Parameter | Example | Required | Description
 --------- | ------- | -------- | -----------
-`token`   | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token
+`token`   | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token.
 `roomid` | `433` | Optional | The room ID (not to be confused, with the `roomname`).
 `roomname` | `Torrington (1-19) 433`| Optional | The name of the room. It often includes the name of the site (building) as well.
 `siteid` | `086`| Optional | Every room is inside a site (building). All sites have IDs.
 `sitename` | `Torrington Place, 1-19`| Optional | Every site (building) has a name. In some cases this is contained in the `roomname` as well.
-`classification` | `CR`| Optional | The type of room. `LT` = Lecture Theatre, `CR` = Classroom, `SS` = Social Space, `PC1` = Public Cluster
+`classification` | `CR`| Optional | The type of room. `LT` = Lecture Theatre, `CR` = Classroom, `SS` = Social Space, `PC1` = Public Cluster.
 `capacity` | `55`| Optional | Every room has a set capacity of how many people can fit inside it. When supplied, all rooms with the given capacity or greater will be returned.
 
 ### Response
@@ -158,11 +158,11 @@ The room field contains a list of rooms that match your query. If no filters are
 Room Property | Example |  Description
 --------- | ---------- |  -----------
 `roomname` | `Wilkins Building (Main Building) Portico` | The name of the room. It often includes the name of the site (building) as well.
-`roomid` | `Z4` | The room ID (not to be confused with the `roomname`)
+`roomid` | `Z4` | The room ID (not to be confused with the `roomname`).
 `siteid` | `005`| Every room is inside a site (building). All sites have IDs.
 `sitename` | `Main Building` | The name of the site (building).
 `capacity` | `50` | The number of people that can fit in the room.
-`classification` | `SS`| The type of room. `LT` = Lecture Theatre, `CR` = Classroom, `SS` = Social Space, `PC1` = Public Cluster
+`classification` | `SS`| The type of room. `LT` = Lecture Theatre, `CR` = Classroom, `SS` = Social Space, `PC1` = Public Cluster.
 `automated` | `N` | Whether bookings in this room will be confirmed automatically. `A` stands for automated, and `N` for not automated. `P` represents that the confirmation will be automatic, but only under certain circumstances.
 `location` | - | Contains an object with the key `address`, whose value is an array of address information, which when combined will make up a complete address.
 
@@ -214,8 +214,8 @@ fetch("https://uclapi.com/roombookings/bookings?token=uclapi-5d58c3c4e6bf9c-c291
 
 Parameter | Example | Required | Description
 ---|---|---|---
-token | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token
-roomid |  `433`  |  Optional  | The room ID (not to be confused with the `roomname`)
+token | `uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb` | Required | Authentication token.
+roomid |  `433`  |  Optional  | The room ID (not to be confused with the `roomname`).
 start_datetime | `2011-03-06T03:36:45+00:00` | Optional | Start datetime of the booking. Returns bookings with a `start_datetime` after the one supplied. Follows the [ISO 8601 formatting standard](https://en.wikipedia.org/wiki/ISO_8601).
 end_datetime | `2011-03-06T03:36:45+00:00` | Optional | End datetime of the booking. Returns bookings with an `end_datetime` before the one supplied. Follows the [ISO 8601 formatting standard](https://en.wikipedia.org/wiki/ISO_8601).
 date | `20160202` | Optional | Date of the bookings you need, in the format *YYYYMMDD*. Returns bookings occurring on this day. **This query parameter is only considered when `end_datetime` and `start_datetime` are not supplied.**
@@ -352,9 +352,9 @@ Error                 | Description
 ----------------------| -----------
 `No token provided`   | Gets returned when you have not supplied a `token` in your request.
 `Token does not exist`| Gets returned when you supply an invalid `token`.
-`date/time isn't formatted as suggested in the docs`  | Passed datetime parameter do not conform to the ISO8601 format
+`date/time isn't formatted as suggested in the docs`  | Passed datetime parameter does not conform to the ISO8601 format
 `results_per_page should be an integer`  | `results_per_page` should always be an integer.
-`Page token does not exist` | passed `page_token` parameter isn't a valid one.
+`Page token does not exist` | The passed `page_token` parameter isn't a valid one.
 
 ## Get Equipment
 **Endpoint:** `https://uclapi.com/roombookings/equipment`


### PR DESCRIPTION
- id -> ID
- grammar fixes
- additional detail on date format
- added roomname to parameters for bookings
- room name -> `roomname` in parameter descriptions
- changed bookings response example to fit order of description table
- added society and student group info to description of contact parameter
- quotation marks around remember
- some changes of phrasing in pagination description 
- fullstops
- updated descriptions of errors in bookings