### PR TITLE
Added required params to the equipment examples

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -372,18 +372,24 @@ You _need_ to supply a `token`, `roomid`, and `siteid` to get a response.
 ### Query Parameters
 
 ```shell
-curl https://uclapi.com/roombookings/equipment?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb
+curl https://uclapi.com/roombookings/equipment?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&roomid=433&siteid=086
 ```
 
 ```python
 import requests
 
-r = requests.get("https://uclapi.com/roombookings/equipment?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb")
+params = {
+  "token": "uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb",
+  "roomid": "433"
+  "siteid": "086"
+}
+
+r = requests.get("https://uclapi.com/roombookings/equipment", params=params)
 print(r.json())
 ```
 
 ```javascript
-fetch("https://uclapi.com/roombookings/equipment?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb")
+fetch("https://uclapi.com/roombookings/equipment?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&roomid=433&siteid=086")
 .then((response) => {
   return response.json()
 })


### PR DESCRIPTION
This should fix the `equipment` endpoint requests.
I have added the mandatory params to all the examples, Shell, Python and JavaScript.

tiferrei