### PR TITLE
Remove hyphenation from inline code

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -413,7 +413,7 @@ html, body {
       td:nth-child(2) {
         width: 80px;
       }
-    } 
+    }
     th {
       padding: 5px 10px;
       border-bottom: 1px solid #ccc;
@@ -458,7 +458,8 @@ html, body {
     background-color: rgba(0,0,0,0.05);
     padding: 3px;
     border-radius: 3px;
-    @extend %break-words;
+    word-break: break-word;
+    hyphens: none;
     @extend %code-font;
   }
 


### PR DESCRIPTION
On small screen widths, such as on mobile devices, text formatted as inline code is hyphenated. Since there are hyphens in the URLs, this makes it confusing to read in instances like the following (at a glance, it looks like the endpoint url could be `https://uclapi.com/room-bookings/`):

<img width="426" alt="screen shot 2017-09-30 at 11 12 09" src="https://user-images.githubusercontent.com/19519457/31044942-325ceb7a-a5d1-11e7-99c8-8d6d746b712d.png">

I propose changing the styling on inline code to remove these hyphens and remove line breaks in the middle of words. This yields the following:

<img width="426" alt="screen shot 2017-09-30 at 11 12 48" src="https://user-images.githubusercontent.com/19519457/31044983-0b1a9868-a5d2-11e7-8234-dfa79dcdfa00.png">

The change would bring the docs in line with Github's rendering of Markdown code snippets on mobile.

Side effects:

- More space around inline code
- Hyphens in non-URLs in code blocks also disappear, e.g.:

<img width="424" alt="screen shot 2017-09-30 at 11 13 07" src="https://user-images.githubusercontent.com/19519457/31044995-3e5da346-a5d2-11e7-9597-cc96429beb67.png">

becomes

<img width="424" alt="screen shot 2017-09-30 at 11 29 41" src="https://user-images.githubusercontent.com/19519457/31045023-aef2442c-a5d2-11e7-9d5b-d52913766ed9.png">



