### PR TITLE
nuke the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-!!!!! STOP AND READ !!!!!
-
-If the dropdown above says "base fork: lord/master", you are submitting your change to ALL USERS OF SLATE, not just your company. This is probably not what you want. Click "base fork" to change it to the right place.
-
-If you're actually trying to submit a change to upstream Slate, please submit to our dev branch, PRs sent to the master branch are generally rejected.


### PR DESCRIPTION
This is a standalone repo, so there should be no instance when a user accidentally PRs against the upstream slate repo - hence this warning isn't necessary.