### PR TITLE
Correct allowed method for timetable/bymodule from POST to GET

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -993,7 +993,7 @@ Version Header | Latest Version
 
 This endpoint returns a yearly timetable for the supplied modules.
 
-**Allowed request type:** `POST`
+**Allowed request type:** `GET`
 
 ### Query Parameters
 


### PR DESCRIPTION
The allowed request type for `timetable/bymodule` is currently listed as `POST`, but the endpoint actually only accepts `GET` requests. The code examples are correct - it's just the main body that isn't right.